### PR TITLE
Implement timeline view for posts

### DIFF
--- a/src/app/(app)/posts/TimelinePostItem.tsx
+++ b/src/app/(app)/posts/TimelinePostItem.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import dayjs from 'dayjs';
+import { AspectRatio } from '@/components/ui/aspect-ratio';
+import { Tag } from './TagItem';
+import { cn } from '@/lib/utils';
+import { Post } from 'contentlayer/generated';
+
+interface Props {
+	post: Post;
+	showCover?: boolean;
+	isLast?: boolean;
+}
+
+export default function TimelinePostItem({ post, showCover, isLast }: Props) {
+	return (
+		<li
+			className={cn(
+				'relative pl-8 pb-8',
+				!isLast && 'border-l border-zinc-300 dark:border-zinc-700'
+			)}
+		>
+			<span className="absolute left-[-7px] top-2 flex h-3 w-3 rounded-full bg-violet-500 ring-2 ring-white dark:ring-zinc-900" />
+			{showCover && post.cover && (
+				<AspectRatio ratio={16 / 9} className="mb-3 rounded-md overflow-hidden">
+					<Image
+						src={post.cover}
+						alt={post.title}
+						fill
+						unoptimized
+						className="object-cover"
+					/>
+				</AspectRatio>
+			)}
+			<Link href={`/posts/${post.slug}`} className="group block">
+				<h2 className="text-lg font-medium group-hover:text-violet-600 dark:group-hover:text-violet-400">
+					{post.title}
+				</h2>
+			</Link>
+			<div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+				<time dateTime={post.date}>
+					{dayjs(post.date).format('YYYY-MM-DD')}
+				</time>
+				{post.tags.map((tag) => (
+					<Tag key={tag}>{tag}</Tag>
+				))}
+			</div>
+		</li>
+	);
+}

--- a/src/app/(app)/posts/page.tsx
+++ b/src/app/(app)/posts/page.tsx
@@ -1,13 +1,8 @@
 import { Container } from '@/components/Container';
-import { AspectRatio } from '@/components/ui/aspect-ratio';
-import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
-import { allPosts, type Post } from 'contentlayer/generated';
-import dayjs from 'dayjs';
-import Image from 'next/image';
-import Link from 'next/link';
+import { allPosts } from 'contentlayer/generated';
 import CoverSwitch from './CoverSwitch';
-import { Tag } from './TagItem';
+import TimelinePostItem from './TimelinePostItem';
 
 export interface PostItem {
 	title: string;
@@ -19,47 +14,6 @@ export interface PostItem {
 	author: string;
 	cover?: string;
 } // components/Tag.js
-
-function PostCard({ post, showCover }: { post: Post; showCover?: boolean }) {
-	return (
-		<Link
-			href={`/posts/${post.slug}`}
-			className={cn(
-				'text-violet-500 relative dark:text-violet-400',
-				showCover ? 'hover:drop-shadow-2xl' : ' hover:text-violet-700'
-			)}
-		>
-			{showCover && (
-				<AspectRatio
-					ratio={16 / 9}
-					className="bg-muted absolute left-0 top-0 rounded-md overflow-hidden"
-				>
-					<Image
-						unoptimized
-						src={post.cover ?? ''}
-						alt={post.title}
-						fill
-						className=" object-cover"
-					/>
-				</AspectRatio>
-			)}
-			<div className="px-4 py-4 rounded-sm border-b-[1px] border-violet-200 sm:border-none  cursor-pointer">
-				<h2 className="mb-1 text-xl font-medium">
-					<span>{post.title}</span>
-				</h2>
-				<div className="hidden sm:flex flex-wrap mt-2 justify-start  items-center space-x-4 text-sm">
-					<time dateTime={post.date} className=" block text-xs text-gray-600">
-						{dayjs(post.date).format('YYYY-MM-DD')}
-					</time>
-					<Separator orientation="vertical" className="h-5" />
-					{post.tags.map((tag) => (
-						<Tag key={tag}>{tag}</Tag>
-					))}
-				</div>
-			</div>
-		</Link>
-	);
-}
 const title = '我的博客列表 | ';
 const description =
 	'记录在编程学习、工作中遇到的问题。我精心整理为技术博客文章合集，涵盖前端开发、React、Next.js等热门话题。发现实用的开发技巧、最佳实践和行业动态，提升您的开发技能。立即浏览最新文章！';
@@ -104,11 +58,15 @@ export default function Posts() {
 					，偶尔也会记录 <b>其他内容</b>
 				</p>
 			</header>
-			<div className={cn('grid grid-cols-1 gap-4', false ? 'grid-cols-2' : '')}>
+			<ul className="mt-8">
 				{sortedPosts.map((post, idx) => (
-					<PostCard showCover={false} key={idx} post={post} />
+					<TimelinePostItem
+						key={post._id}
+						post={post}
+						isLast={idx === sortedPosts.length - 1}
+					/>
 				))}
-			</div>
+			</ul>
 		</Container>
 	);
 }


### PR DESCRIPTION
## Summary
- redesign `/posts` with a vertical timeline layout
- add `TimelinePostItem` component for each post entry

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_b_68491893e9e4832db16f037c3244d625