### PR TITLE
Add christmas theme experience

### DIFF
--- a/public/christmas/santa.svg
+++ b/public/christmas/santa.svg
@@ -1,0 +1,22 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+<title id="title">Santa</title>
+<desc id="desc">A friendly Santa illustration</desc>
+<g fill="none" fill-rule="evenodd">
+  <circle cx="100" cy="100" r="96" fill="#F2D7C4"/>
+  <path d="M30 96c6-36 34-62 70-62s63 27 70 62" fill="#D9252A"/>
+  <path d="M42 101c4-28 30-48 58-48s54 20 58 48" fill="#E7464A"/>
+  <path d="M54 122c0-30 21-51 46-51 25 0 46 21 46 51 0 30-21 51-46 51-25 0-46-21-46-51Z" fill="#FFF"/>
+  <path d="M70 125c0-11 9-21 30-21 22 0 30 10 30 21s-8 21-30 21c-21 0-30-10-30-21Z" fill="#F8B49A"/>
+  <circle cx="80" cy="116" r="6" fill="#3C2A20"/>
+  <circle cx="120" cy="116" r="6" fill="#3C2A20"/>
+  <path d="M92 140c5 4 11 6 18 6 6 0 12-2 16-5" stroke="#3C2A20" stroke-width="4" stroke-linecap="round"/>
+  <rect x="38" y="90" width="124" height="20" rx="10" fill="#FFF"/>
+  <circle cx="60" cy="90" r="8" fill="#FFF"/>
+  <circle cx="140" cy="90" r="8" fill="#FFF"/>
+  <circle cx="48" cy="80" r="5" fill="#FFF"/>
+  <circle cx="152" cy="80" r="5" fill="#FFF"/>
+  <path d="M82 67c4-6 11-10 18-10 7 0 14 4 18 10" stroke="#FFF" stroke-width="7" stroke-linecap="round"/>
+  <path d="M68 158c12 8 24 12 32 12 10 0 21-4 32-12l-8 18c-5 3-15 6-24 6-9 0-19-3-24-6l-8-18Z" fill="#D9252A"/>
+  <circle cx="100" cy="164" r="6" fill="#F7C948"/>
+</g>
+</svg>

--- a/public/christmas/snowflake.svg
+++ b/public/christmas/snowflake.svg
@@ -1,0 +1,10 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+<title id="title">Snowflake</title>
+<desc id="desc">Geometric snowflake</desc>
+<g fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M60 6v108M60 6l12 18M60 6l-12 18M60 114l12-18M60 114l-12-18"/>
+  <path d="M14 34l92 52M14 34l22 2M14 34l-6 20M106 86l-22-2M106 86l6-20"/>
+  <path d="M106 34L14 86M106 34l-22 2M106 34l6 20M14 86l22-2M14 86l-6-20"/>
+  <circle cx="60" cy="60" r="10" fill="#ffffff"/>
+</g>
+</svg>

--- a/public/christmas/tree.svg
+++ b/public/christmas/tree.svg
@@ -1,0 +1,17 @@
+<svg width="180" height="200" viewBox="0 0 180 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+<title id="title">Christmas Tree</title>
+<desc id="desc">Layered evergreen tree with ornaments</desc>
+<g fill="none" fill-rule="evenodd">
+  <polygon points="90 8 102 32 128 36 108 54 112 78 90 66 68 78 72 54 52 36 78 32" fill="#F7C948"/>
+  <polygon points="90 22 140 92 110 92 138 132 112 132 146 176 34 176 68 132 42 132 70 92 40 92" fill="#1E7A46"/>
+  <rect x="78" y="176" width="24" height="20" rx="4" fill="#9C6B3D"/>
+  <circle cx="70" cy="106" r="6" fill="#F0533D"/>
+  <circle cx="112" cy="112" r="6" fill="#FFF"/>
+  <circle cx="88" cy="142" r="6" fill="#F7C948"/>
+  <circle cx="116" cy="86" r="5" fill="#F7C948"/>
+  <circle cx="62" cy="82" r="5" fill="#FFF"/>
+  <circle cx="90" cy="60" r="4" fill="#F0533D"/>
+  <circle cx="128" cy="144" r="5" fill="#F7C948"/>
+  <circle cx="52" cy="134" r="5" fill="#F0533D"/>
+</g>
+</svg>

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
 			{/* 内容区域盒子 */}
 			<div className="fixed inset-0 flex justify-center sm:px-8">
 				<div className="flex w-full max-w-7xl lg:px-8">
-					<div className="opacity-95 w-full bg-zinc-50/90 ring-1 ring-zinc-100 dark:bg-zinc-900/80 dark:ring-zinc-400/20" />
+					<div className="holiday-frame opacity-95 w-full bg-zinc-50/90 ring-1 ring-zinc-100 dark:bg-zinc-900/80 dark:ring-zinc-400/20" />
 				</div>
 			</div>
 			<div className="relative text-zinc-800 dark:text-zinc-200">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,12 +57,40 @@
 		--chart-4: 280 65% 60%;
 		--chart-5: 340 75% 55%;
 	}
+
+	.christmas {
+		--background: 141 45% 96%;
+		--foreground: 150 20% 10%;
+		--card: 141 60% 96%;
+		--card-foreground: 150 25% 15%;
+		--popover: 141 60% 96%;
+		--popover-foreground: 150 25% 15%;
+		--primary: 356 67% 48%;
+		--primary-foreground: 0 0% 98%;
+		--secondary: 142 35% 88%;
+		--secondary-foreground: 150 25% 15%;
+		--muted: 150 25% 90%;
+		--muted-foreground: 142 20% 32%;
+		--accent: 42 92% 68%;
+		--accent-foreground: 156 44% 16%;
+		--destructive: 0 84% 60%;
+		--destructive-foreground: 0 0% 100%;
+		--border: 142 25% 80%;
+		--input: 142 25% 84%;
+		--ring: 356 67% 48%;
+		--radius: 0.75rem;
+		--chart-1: 356 67% 48%;
+		--chart-2: 142 50% 38%;
+		--chart-3: 42 92% 68%;
+		--chart-4: 205 80% 72%;
+		--chart-5: 30 95% 64%;
+	}
 }
 /* 切换主题动画 */
 ::view-transition-old(root),
 ::view-transition-new(root) {
-  animation: none;
-  mix-blend-mode: normal;
+	animation: none;
+	mix-blend-mode: normal;
 }
 @layer base {
 	* {
@@ -70,5 +98,63 @@
 	}
 	body {
 		@apply bg-background text-foreground;
+	}
+}
+
+.christmas body {
+	background:
+		radial-gradient(
+			circle at 15% 20%,
+			rgba(255, 255, 255, 0.4),
+			transparent 30%
+		),
+		radial-gradient(
+			circle at 80% 10%,
+			rgba(255, 255, 255, 0.25),
+			transparent 28%
+		),
+		linear-gradient(
+			180deg,
+			rgba(35, 71, 45, 0.8) 0%,
+			rgba(16, 32, 23, 0.95) 60%,
+			rgba(22, 13, 20, 0.95) 100%
+		),
+		#0f1a12;
+	color: #0e1a14;
+}
+
+.christmas .holiday-frame {
+	background: linear-gradient(
+		135deg,
+		rgba(255, 255, 255, 0.9),
+		rgba(255, 245, 234, 0.85)
+	);
+	border: 1px solid rgba(255, 255, 255, 0.6);
+	box-shadow:
+		0 10px 45px rgba(20, 50, 30, 0.35),
+		0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.snow-layer {
+	position: absolute;
+	inset: 0;
+	background-image:
+		url('/christmas/snowflake.svg'), url('/christmas/snowflake.svg');
+	background-repeat: repeat;
+	background-size: 120px, 80px;
+	animation: snowfall 18s linear infinite;
+	opacity: 0.5;
+}
+
+@keyframes snowfall {
+	from {
+		background-position:
+			0 0,
+			0 0;
+	}
+	to {
+		background-position:
+			0 900px,
+			0 600px;
 	}
 }

--- a/src/components/ChristmasTreeButton.tsx
+++ b/src/components/ChristmasTreeButton.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { TreePine } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useEffect, useMemo, useState } from 'react';
+
+function isWithinChristmasWindow(date: Date) {
+	const month = date.getMonth();
+	const day = date.getDate();
+
+	// Show from November 25 (one month before Christmas) until December 28 (3 days after)
+	return (month === 10 && day >= 25) || (month === 11 && day <= 28);
+}
+
+export default function ChristmasTreeButton() {
+	const { setTheme, theme } = useTheme();
+	const [mounted, setMounted] = useState(false);
+	const [shouldShow, setShouldShow] = useState(false);
+
+	useEffect(() => {
+		setMounted(true);
+		setShouldShow(isWithinChristmasWindow(new Date()));
+	}, []);
+
+	const isChristmasTheme = useMemo(() => theme === 'christmas', [theme]);
+
+	if (!mounted || !shouldShow) return null;
+
+	return (
+		<button
+			type="button"
+			aria-label="开启圣诞节主题"
+			className={cn(
+				'relative inline-flex h-10 items-center rounded-full px-4 text-sm font-medium text-white shadow-lg shadow-red-500/30 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2',
+				'bg-gradient-to-r from-emerald-500 via-red-500 to-amber-400 hover:scale-[1.02] hover:shadow-red-500/50 focus:ring-red-300 dark:focus:ring-red-700',
+				isChristmasTheme && 'ring-2 ring-offset-2 ring-white/70'
+			)}
+			onClick={() => setTheme('christmas')}
+		>
+			<span className="mr-2 inline-flex h-7 w-7 items-center justify-center rounded-full bg-white/20 text-lg">
+				🎄
+			</span>
+			<span className="mr-1 hidden sm:inline">提前感受圣诞</span>
+			<TreePine className="h-5 w-5" />
+			<span
+				aria-hidden
+				className="pointer-events-none absolute inset-[-2px] rounded-full border border-white/40 bg-gradient-radial from-white/30 via-transparent to-transparent opacity-80"
+			/>
+		</button>
+	);
+}

--- a/src/components/GlobalBg.tsx
+++ b/src/components/GlobalBg.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { cn } from '@/lib/utils';
+import Image from 'next/image';
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 
@@ -12,13 +14,45 @@ export function GlobalBg() {
 	}, []);
 
 	// 根据主题和 mounted 状态，返回不同的 className
+	const isChristmas = theme === 'christmas' && mounted;
+
 	return (
-		<div
-			className={`z-[-1] absolute bottom-0 left-0 right-0 top-0 bg-[linear-gradient(to_right,#4f4f4f2e_1px,transparent_1px),linear-gradient(to_bottom,#4f4f4f2e_1px,transparent_1px)] bg-[size:14px_24px] ${
-				theme === 'dark' && mounted // 注意这里增加了 mounted 判断
-					? '[mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)]'
-					: '[mask-image:radial-gradient(ellipse_80%_50%_at_50%_0%,#000_70%,transparent_110%)]'
-			}`}
-		/>
+		<div className="pointer-events-none absolute inset-0 z-[-1] overflow-hidden">
+			<div
+				className={cn(
+					'absolute inset-0 bg-[linear-gradient(to_right,#4f4f4f2e_1px,transparent_1px),linear-gradient(to_bottom,#4f4f4f2e_1px,transparent_1px)] bg-[size:14px_24px]',
+					mounted &&
+						(theme === 'dark'
+							? '[mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)]'
+							: '[mask-image:radial-gradient(ellipse_80%_50%_at_50%_0%,#000_70%,transparent_110%)]'),
+					isChristmas && 'hidden'
+				)}
+			/>
+
+			{isChristmas && (
+				<>
+					<div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.32),transparent_45%),radial-gradient(circle_at_80%_30%,rgba(255,255,255,0.22),transparent_42%),linear-gradient(135deg,#1f3d2b_0%,#0f1f16_30%,#1a0f12_70%,#2a0a0f_100%)]" />
+					<div className="snow-layer" aria-hidden />
+					<div className="absolute inset-x-0 top-0 flex justify-between px-8 pt-10">
+						<Image
+							src="/christmas/santa.svg"
+							alt="Santa"
+							width={112}
+							height={112}
+							className="h-24 w-24 drop-shadow-lg md:h-28 md:w-28"
+							priority
+						/>
+						<Image
+							src="/christmas/tree.svg"
+							alt="Christmas tree"
+							width={96}
+							height={128}
+							className="h-24 w-20 drop-shadow-lg md:h-28 md:w-24"
+							priority
+						/>
+					</div>
+				</>
+			)}
+		</div>
 	);
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,6 +26,10 @@ import dynamic from 'next/dynamic';
 const ThemeToggle = dynamic(() => import('./ThemeToggle'), {
 	ssr: false
 });
+
+const ChristmasTreeButton = dynamic(() => import('./ChristmasTreeButton'), {
+	ssr: false
+});
 export function Header() {
 	const isHomePage = usePathname() === '/';
 
@@ -272,6 +276,9 @@ export function Header() {
 								animate={{ opacity: 1, y: 0, scale: 1 }}
 							>
 								{/* <UserInfo /> */}
+								<div className="pointer-events-auto">
+									<ChristmasTreeButton />
+								</div>
 								<div className="pointer-events-auto">
 									<ThemeToggle />
 								</div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -23,8 +23,12 @@ export default function ThemeToggle() {
 	useEffect(() => {
 		const link = document.createElement('link');
 		link.rel = 'stylesheet';
-		link.href =
-			theme === 'dark'
+		const isDark = theme === 'dark';
+		const isChristmas = theme === 'christmas';
+
+		link.href = isDark
+			? '/style/prism-gruvbox-light.css'
+			: isChristmas
 				? '/style/prism-gruvbox-light.css'
 				: '/style/prism-coldark-dark.css';
 		document.head.appendChild(link);


### PR DESCRIPTION
## Summary
- add a seasonal Christmas tree button that appears before the holiday and activates the Christmas theme
- introduce a Christmas visual theme with Santa, tree, and snow overlays plus festive color tokens
- adjust layout container styling and prism stylesheet selection to support the new theme

## Testing
- pnpm lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e8f1331ac832eb3feb5834e211c8d)