### PR TITLE
Prevent duplicate Sync Post workflow runs

### DIFF
--- a/.github/workflows/sync-post.yml
+++ b/.github/workflows/sync-post.yml
@@ -16,6 +16,13 @@ on:
       - reopened
       - committed # 修改？
   workflow_dispatch:
+
+# Avoid overlapping runs when multiple issue events happen in quick
+# succession (e.g., labeling and editing) to prevent duplicate CI
+# executions for the same trigger.
+concurrency:
+  group: sync-post-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   GH_USER: ${{ secrets.GH_USER }}


### PR DESCRIPTION
## Summary
- add workflow concurrency settings for Sync Post to avoid overlapping runs
- document reason to prevent duplicate executions when multiple issue events arrive at once

## Testing
- not run (not applicable for workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e8f3835fc832ea26eb07fb9e77ab7)